### PR TITLE
Identify joystick via VendorID rather than user setting

### DIFF
--- a/src/InputHandler.cpp
+++ b/src/InputHandler.cpp
@@ -43,6 +43,20 @@ void InputHandler::handleEvents(sf::RenderWindow &window)
 	while (window.pollEvent(event))
 	{
 		ImGui::SFML::ProcessEvent(window, event);
+
+		if (sf::Joystick::isConnected(0))
+		{
+			auto id = sf::Joystick::getIdentification(0);
+			if (id.vendorId == 1118)
+			{
+				m_padType = PadType::Xbox_Pad;
+			}
+			else if (id.vendorId == 1356)
+			{
+				m_padType = PadType::DS4_Pad;
+			}
+		}
+
 #if defined(IMPOSSIBLE_ROCKET_DEBUG)
 		if (event.type == sf::Event::Closed)
 			window.close();
@@ -86,11 +100,6 @@ auto InputHandler::getInputState() const -> InputState
 auto InputHandler::wasResetPressed() const -> bool
 {
 	return m_resetPressed;
-}
-
-auto InputHandler::getPadType() const -> PadType
-{
-	return m_padType;
 }
 
 auto InputHandler::debugSkipPressed() const -> bool
@@ -153,22 +162,6 @@ void InputHandler::handleKeyboard(const sf::Event &event)
 
 		if (event.key.code == sf::Keyboard::H)
 			m_haltKeyPressed = true;
-
-		if (event.key.code == sf::Keyboard::F3)
-		{
-			switch (m_padType)
-			{
-			case PadType::Xbox_Pad:
-				m_padType = PadType::DS4_Pad;
-				break;
-			case PadType::DS4_Pad:
-				m_padType = PadType::Xbox_Pad;
-				break;
-			default:
-				assert(false);
-				break;
-			}
-		}
 
 		if (event.key.code == sf::Keyboard::Key::W)
 			m_state.linear_thrust = 0.0f;

--- a/src/InputHandler.hpp
+++ b/src/InputHandler.hpp
@@ -22,7 +22,6 @@ public:
 
 	auto getInputState() const -> InputState;
 	auto wasResetPressed() const -> bool;
-	auto getPadType() const -> PadType;
 	auto debugSkipPressed() const -> bool;
 	auto getMousePosition() const -> sf::Vector2f;
 	auto leftClickPressed() const -> bool;

--- a/src/PlayState.cpp
+++ b/src/PlayState.cpp
@@ -32,11 +32,6 @@ PlayState::PlayState(sf::RenderWindow &window)
 	m_backgroundSprite.setTextureRect({{0, 0}, {600, 400}});
 
 	// In game UI
-	m_uiPadType.setFont(*font);
-	m_uiPadType.setString("Xbox");
-	const auto bounds = m_uiPadType.getGlobalBounds();
-	m_uiPadType.setPosition({800.0f - bounds.width, 0.0f});
-
 	m_uiAttempts.setFont(*font);
 	m_uiAttempts.setString("Attempts: 1");
 
@@ -140,7 +135,6 @@ void PlayState::draw() const
 		m_window.draw(*pe);
 	}
 
-	m_window.draw(m_uiPadType);
 	m_window.draw(m_uiAttempts);
 	if (m_isOutOfBounds)
 	{
@@ -161,7 +155,6 @@ void PlayState::updatePlaying(const sf::Time &dt)
 {
 	auto &input = InputHandler::get();
 	const bool skipLevel = input.debugSkipPressed();
-	static auto padType = input.getPadType();
 	static sf::Uint32 attempts = m_gameLevel.getAttemptTotal();
 
 	// Update core gameplay & ImGui
@@ -197,26 +190,6 @@ void PlayState::updatePlaying(const sf::Time &dt)
 			m_gameLevel.loadLevel(static_cast<GameLevel::Levels>(current + 1));
 			m_rocket.levelStart();
 		}
-	}
-
-	// Update pad type UI
-	if (input.getPadType() != padType)
-	{
-		padType = input.getPadType();
-		switch (padType)
-		{
-		case InputHandler::PadType::Xbox_Pad:
-			m_uiPadType.setString("Xbox");
-			break;
-
-		case InputHandler::PadType::DS4_Pad:
-			m_uiPadType.setString("DS4");
-			break;
-		default:
-			break;
-		}
-		const auto bounds = m_uiPadType.getGlobalBounds();
-		m_uiPadType.setPosition({800 - bounds.width, 0.0f});
 	}
 
 	if (attempts != m_gameLevel.getAttemptTotal())

--- a/src/PlayState.hpp
+++ b/src/PlayState.hpp
@@ -41,7 +41,6 @@ private:
 	sf::RectangleShape m_oobDirectionIndicator;
 	sf::RectangleShape m_pauseMenuDim;
 
-	sf::Text m_uiPadType;
 	sf::Text m_uiAttempts;
 	sf::Text m_uiOOB;
 	sf::Text m_uiPauseTitle;


### PR DESCRIPTION
- Remove UI to display pad input type
- Identify preferred pad input setup by vendorID