### PR TITLE
Fix incorrect boolean logic

### DIFF
--- a/src/InputHandler.cpp
+++ b/src/InputHandler.cpp
@@ -153,7 +153,7 @@ void InputHandler::handleKeyboard(const sf::Event &event)
 		if (event.key.code == sf::Keyboard::P)
 			m_pauseUnpausePressed = true;
 #else
-		if (event.key.code == sf::Keyboard::P || sf::Keyboard::Escape)
+		if (event.key.code == sf::Keyboard::P || event.key.code == sf::Keyboard::Escape)
 			m_pauseUnpausePressed = true;
 #endif
 


### PR DESCRIPTION
```cpp
/Users/thrasher/Projects/impossible-rocket/src/InputHandler.cpp:156:41: error: converting the enum constant to a boolean [-Werror,-Wint-in-bool-context]
                if (event.key.code == sf::Keyboard::P || sf::Keyboard::Escape)
                                                      ^
```